### PR TITLE
Add Google Drive upload utility and endpoint

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,5 +16,6 @@ chrono = "0.4.40"
 futures = "0.3.31"
 tokio = "1.44.1"
 unicode-segmentation = "1.12.0"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["multipart"] }
+anyhow = "1.0"
 tracing = "0.1.41"

--- a/backend/src/endpoints/drive.rs
+++ b/backend/src/endpoints/drive.rs
@@ -1,0 +1,57 @@
+use actix_web::{
+    dev::ServiceRequest,
+    post,
+    web::{self, Json},
+    HttpRequest, HttpResponse, Responder,
+};
+use clerk_rs::validators::actix::clerk_authorize;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::app_state::AppState;
+use crate::utils::drive::{get_google_oauth_token, upload_bytes_multipart};
+
+#[derive(Deserialize)]
+pub struct DrivePayload {
+    pub file_path: String,
+}
+
+#[post("/drive")]
+pub async fn upload_drive(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    payload: Json<DrivePayload>,
+) -> impl Responder {
+    let srv_req = ServiceRequest::from_request(req);
+    if let Err(e) = clerk_authorize(&srv_req, &state.client, true).await {
+        return e;
+    }
+
+    let token = match get_google_oauth_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": e.to_string()}));
+        }
+    };
+
+    let bytes = match tokio::fs::read(&payload.file_path).await {
+        Ok(b) => b,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({
+                "error": format!("Unable to read {}: {e}", payload.file_path)
+            }));
+        }
+    };
+
+    let file_name = std::path::Path::new(&payload.file_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("file.mp3");
+
+    if let Err(e) = upload_bytes_multipart(&bytes, "audio/mpeg", file_name, &token).await {
+        return HttpResponse::InternalServerError().json(json!({"error": e.to_string()}));
+    }
+
+    HttpResponse::Ok().json(json!({"status": "uploaded"}))
+}

--- a/backend/src/endpoints/mod.rs
+++ b/backend/src/endpoints/mod.rs
@@ -1,3 +1,4 @@
 pub mod files;
 pub mod speech;
 pub mod analysis;
+pub mod drive;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -113,7 +113,8 @@ async fn main(
                 .service(get_users)
                 .service(get_speech)
                 .service(list_speech_files)
-                .service(upload_analysis),
+                .service(upload_analysis)
+                .service(endpoints::drive::upload_drive),
         )
         // serve the build files from the frontend
         .service(actix_files::Files::new("/", "./frontend/dist").index_file("index.html"))

--- a/backend/src/utils/drive.rs
+++ b/backend/src/utils/drive.rs
@@ -1,0 +1,53 @@
+use anyhow::{anyhow, Result};
+use reqwest::{multipart, Client};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize)]
+struct GoogleToken {
+    access_token: String,
+}
+
+/// Fetch the Google OAuth access token. In this example we simply read
+/// the `GOOGLE_DRIVE_TOKEN` environment variable. In a real application
+/// this would call Clerk's OAuth access token API.
+pub async fn get_google_oauth_token() -> Result<String> {
+    std::env::var("GOOGLE_DRIVE_TOKEN").map_err(|_| anyhow!("GOOGLE_DRIVE_TOKEN not set"))
+}
+
+/// Upload bytes to Google Drive using the multipart upload API.
+pub async fn upload_bytes_multipart(
+    bytes: &[u8],
+    mime_type: &str,
+    file_name: &str,
+    access_token: &str,
+) -> Result<()> {
+    let metadata = json!({ "name": file_name });
+    let form = multipart::Form::new()
+        .part(
+            "metadata",
+            multipart::Part::text(metadata.to_string())
+                .mime_str("application/json")?,
+        )
+        .part(
+            "file",
+            multipart::Part::bytes(bytes.to_vec()).mime_str(mime_type)?,
+        );
+
+    let client = Client::new();
+    let resp = client
+        .post("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart")
+        .bearer_auth(access_token)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Request error: {e}"))?;
+
+    if resp.status().is_success() {
+        Ok(())
+    } else {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        Err(anyhow!("Upload failed: {status} - {text}"))
+    }
+}

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod chunk_text_unicode;
 pub mod concat_mp3;
+pub mod drive;


### PR DESCRIPTION
## Summary
- add utility for Google Drive OAuth and multipart upload
- expose new utility module
- implement `/drive` endpoint to upload MP3s
- register the drive endpoint in main
- add `anyhow` and enable multipart support for reqwest

## Testing
- `cargo check -p actix-react-clerk` *(fails: could not connect to crates.io)*